### PR TITLE
Goreleaser

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -1,0 +1,21 @@
+builds:
+- env:
+  - CGO_ENABLED=0
+  # GOOS list to build for.
+  # For more info refer to: https://golang.org/doc/install/source#environment
+  # Defaults are darwin and linux.
+  goos:
+    - linux
+    - windows
+    - darwin
+    - freebsd
+    - android
+
+  # GOARCH to build for.
+  # For more info refer to: https://golang.org/doc/install/source#environment
+  # Defaults are 386, amd64 and arm64.
+  goarch:
+    - amd64
+    - arm
+    - arm64
+    - "386"

--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.2
+      -
+        run: cd ${{ github.workspace }}/.. && wget https://raw.githubusercontent.com/PinkDev1/hacker-scoper/main/.github/.goreleaser.yml && pwd
+      -
+        name: run GoReleaser
+        uses: goreleaser/goreleaser-action@v2.4.1
+        with:
+          version: latest
+          args: release --rm-dist --config ${{ github.workspace }}/../.goreleaser.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}

--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: 1.17.2
       -
-        run: cd ${{ github.workspace }}/.. && wget https://raw.githubusercontent.com/PinkDev1/hacker-scoper/main/.github/.goreleaser.yml && pwd
+        run: cd ${{ github.workspace }}/.. && wget https://raw.githubusercontent.com/Josue87/AnalyticsRelationships/main/.github/.goreleaser.yml && pwd
       -
         name: run GoReleaser
         uses: goreleaser/goreleaser-action@v2.4.1


### PR DESCRIPTION
With this github action, everytime a new release of AnalyticsRelationships is made on [the releases tab](https://github.com/Josue87/AnalyticsRelationships/releases), goreleaser will automatically compile and add standalone executables according to its config, creating pre-compiled binaries for many platforms. [Like this](https://github.com/PinkDev1/hacker-scoper/releases/tag/v1.1.0).


I'm adding this as a separate PR because it needs some action from your part @Josue87:
You have to go to these repository's settings and add a github secret named `GITHUBTOKEN` with all the permissions under `repo` .  After that's done, just merge this PR and create a new release on [the releases tab](https://github.com/Josue87/AnalyticsRelationships/releases).

Here's some example token configuration that would work:
![example token config](https://i.imgur.com/rwAMlXN.png)

You can create the token [on this page](https://github.com/settings/tokens/new)
Add it to this project [here](https://github.com/Josue87/AnalyticsRelationships/settings/secrets/actions)

More info here:

- https://github.com/marketplace/actions/goreleaser-action
- https://docs.github.com/en/actions/security-guides/encrypted-secrets
- https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

TL;RD: Only _you_ will be able to access the secret if you set it up with the instructions I gave.